### PR TITLE
fix: pin dependency versions and add comments to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-discord.py>=2.3.2
-python-dotenv>=1.0.0
+# Discord API wrapper — core library for building the bot
+discord.py==2.3.2
+
+# Environment variable management — loads DISCORD_TOKEN from .env file
+python-dotenv==1.0.0


### PR DESCRIPTION
Closes #11

Pins `discord.py` and `python-dotenv` to exact versions (`==`) and adds inline comments explaining each package's role. Prevents silent breakage from upstream updates.